### PR TITLE
Fixed up gem requires

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@
 ### Bundler
 Add this line to your application's `Gemfile`:
 ```ruby
-gem 'jekyll-oembed'
+gem 'jekyll-oembed', :require => 'jekyll_oembed'
 ```
 
 And then execute:
@@ -42,7 +42,7 @@ Create the following plugin in your projects _plugins directory.
 
 ```ruby
 # _plugins/jekyll-oembed-plugin.rb
-require 'jekyll-oembed'
+require 'jekyll_oembed'
 ```
 ## Resources
  - [oEmbed providers](http://www.oembed.com/#section7.1)


### PR DESCRIPTION
Hi again -- just fixed up the require statements in the instructions -- since the gem is named with a dash but the file is named with an underscore, we need to tell bundler what to require for the gem. Similarly, in standalone mode we need to use the underscore name.

Thanks again for pushing the gem -- the more reuse we have this way, the better the Jekyll community gets!
